### PR TITLE
Fix logger.Write method to not use nil field

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -151,7 +151,7 @@ func (l Logger) Write(p []byte) (n int, err error) {
 		// Trim CR added by stdlog.
 		p = p[0 : n-1]
 	}
-	l.Log(string(p), nil)
+	l.Log(string(p))
 	return
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -599,3 +599,12 @@ func TestErrorHandler(t *testing.T) {
 		t.Errorf("ErrorHandler err = %#v, want %#v", got, want)
 	}
 }
+
+func TestWrite(t *testing.T) {
+	out := &bytes.Buffer{}
+	log := New(Writer(out), Fields(Timestamp(false)))
+	log.Write([]byte("test"))
+	if got, want := decodeIfBinaryToString(out.Bytes()), "{\"message\":\"test\"}\n"; got != want {
+		t.Errorf("invalid log output:\ngot:  %v\nwant: %v", got, want)
+	}
+}


### PR DESCRIPTION
Was previously panic'ing as passing `nil` to `l.Log` caused it to try to evaluate a `nil` field.