### PR TITLE
Add LogWithLevel function for logging with dynamic log level

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -24,6 +24,11 @@ func With(options ...rz.LoggerOption) rz.Logger {
 	return logger.With(options...)
 }
 
+// LogWithLevel logs a new message with the given level.
+func LogWithLevel(level LogLevel, message string, fields ...rz.Field) {
+	logger.LogWithLevel(level, message, fields...)
+}
+
 // Debug starts a new message with debug level.
 func Debug(message string, fields ...rz.Field) {
 	logger.Debug(message, fields...)

--- a/logger.go
+++ b/logger.go
@@ -90,6 +90,11 @@ func (l *Logger) GetLevel() LogLevel {
 	return l.level
 }
 
+// LogWithLevel logs a new message with the given level.
+func (l *Logger) LogWithLevel(level LogLevel, message string, fields ...Field) {
+	l.logEvent(level, message, nil, fields)
+}
+
 // Debug logs a new message with debug level.
 func (l *Logger) Debug(message string, fields ...Field) {
 	l.logEvent(DebugLevel, message, nil, fields)

--- a/logger_test.go
+++ b/logger_test.go
@@ -479,6 +479,7 @@ func TestLevelWriter(t *testing.T) {
 	log.Warn("3")
 	log.Error("4")
 	log.Log("nolevel-1")
+	log.LogWithLevel(DebugLevel, "5")
 
 	want := []struct {
 		l LogLevel
@@ -489,6 +490,7 @@ func TestLevelWriter(t *testing.T) {
 		{WarnLevel, `{"level":"warning","message":"3"}` + "\n"},
 		{ErrorLevel, `{"level":"error","message":"4"}` + "\n"},
 		{NoLevel, `{"message":"nolevel-1"}` + "\n"},
+		{DebugLevel, `{"level":"debug","message":"5"}` + "\n"},
 	}
 	if got := lw.ops; !reflect.DeepEqual(got, want) {
 		t.Errorf("invalid ops:\ngot:\n%v\nwant:\n%v", got, want)


### PR DESCRIPTION
Currently there is no simple way to log with a dynamic log level . This adds a new function, `LogWithLevel` that logs the message with the given level.

I was going to call it simply `Log`, but this method already exists.