### PR TITLE
Proof of concept of overwritable fields

### DIFF
--- a/config.go
+++ b/config.go
@@ -60,6 +60,7 @@ func Fields(fields ...Field) LoggerOption {
 		for i := range fields {
 			fields[i](e)
 		}
+		logger.overwritableFields = e.overwritableFields
 		if e.stack != logger.stack {
 			logger.stack = e.stack
 		}

--- a/event.go
+++ b/event.go
@@ -38,6 +38,7 @@ type Event struct {
 	formatter            LogFormatter
 	timestampFunc        func() time.Time
 	encoder              Encoder
+	overwritableFields   map[string]Field
 }
 
 func putEvent(e *Event) {
@@ -87,6 +88,13 @@ func (e *Event) Append(fields ...Field) {
 	for i := range fields {
 		fields[i](e)
 	}
+}
+
+func (e *Event) overwritable(key string, field Field) {
+	if e.overwritableFields == nil {
+		e.overwritableFields = make(map[string]Field)
+	}
+	e.overwritableFields[key] = field
 }
 
 // Fields returns the fields from the event.

--- a/field.go
+++ b/field.go
@@ -54,6 +54,17 @@ func String(key, value string) Field {
 	}
 }
 
+// Overwritable adds a new field, but does not resolve it until the event is logged.
+//
+// Adding another Overwritable field with the same key will cause the previous one to be dropped.
+//
+// Typically the `key` will match the `key` passed to the method creating `Field`, but does not have to.
+func Overwritable(key string, field Field) Field {
+	return func(e *Event) {
+		e.overwritable(key, field)
+	}
+}
+
 // Strings adds the field key with vals as a []string to the *Event context.
 func Strings(key string, value []string) Field {
 	return func(e *Event) {

--- a/logger.go
+++ b/logger.go
@@ -37,6 +37,7 @@ type Logger struct {
 	timestampFunc        func() time.Time
 	contextMutext        *sync.Mutex
 	encoder              Encoder
+	overwritableFields   map[string]Field
 }
 
 // New creates a root logger with given options. If the output writer implements
@@ -178,6 +179,9 @@ func (l *Logger) logEvent(level LogLevel, message string, done func(string), fie
 	for i := range fields {
 		fields[i](e)
 	}
+	for i := range e.overwritableFields {
+		e.overwritableFields[i](e)
+	}
 
 	writeEvent(e, message, done)
 }
@@ -290,4 +294,5 @@ func copyInternalLoggerFieldsToEvent(l *Logger, e *Event) {
 	e.formatter = l.formatter
 	e.timestampFunc = l.timestampFunc
 	e.encoder = l.encoder
+	e.overwritableFields = l.overwritableFields
 }

--- a/logger.go
+++ b/logger.go
@@ -179,8 +179,8 @@ func (l *Logger) logEvent(level LogLevel, message string, done func(string), fie
 	for i := range fields {
 		fields[i](e)
 	}
-	for i := range e.overwritableFields {
-		e.overwritableFields[i](e)
+	for key := range e.overwritableFields {
+		e.overwritableFields[key](e)
 	}
 
 	writeEvent(e, message, done)


### PR DESCRIPTION
I have an unusual use-case where I'd like to overwrite fields previously added to a logger via `With(rz.Fields())` to support recursive `context.Context` usage.

Specifically, I've created a tracer for the https://github.com/99designs/gqlgen library where I add the current field being resolved to the logger (stored and retrieved from the `context.Context`), but, as GraphQL fields are resolved recursively, I end up with JSON having duplicate keys in children fields like:

```json
{
  "gql_resolver_object":"Query",
  "gql_resolver_field":"me",
  "gql_resolver_alias":"me",
  "resolver_path": ["me"],

  "gql_resolver_object":"User",
  "gql_resolver_field":"email",
  "gql_resolver_alias":"email",
  "resolver_path":["me", "email"],

  "event":"gql_field_resolved",
  "duration":149846132,
  "gql_errors": [],
  "timestamp":"2019-07-24T14:23:02Z",
  "message":"gql field resolved"
}
```

My formatting added for clarity.

What I'd like is for the last field added with a given key to be applied when writing out the log message.

I took a stab at adding this functionality here via an `Overwritable` function implementing the `Field` signature that, instead of sending it directly to the encoder, merely stores it in a `map`. When the event is written out, the fields in that map are then resolved. This allows a user to opt into this behavior for fields they know that they will be overwriting as I think this likely adds some overhead to the logging.

Example code using my added function:

```golang
package main

import "github.com/bloom42/rz-go"

func main() {
	l := rz.New()

	l = l.With(
		rz.Fields(
			rz.Overwritable("component", rz.String("component", "foo")),
		),
	)
	l = l.With(
		rz.Fields(
			rz.Overwritable("component", rz.String("component", "bar")),
		),
	)

	l.Info("hello")
}
```

Which results in:

```json
{"level":"info","component":"bar","timestamp":"2019-07-24T14:29:53Z","message":"hello"}
```

Instead of:

```json
{"level":"info","component":"foo","component":"bar","timestamp":"2019-07-24T15:00:35Z","message":"hello"}
```

I think I'm probably missing some edge cases, but wanted to get this up to see if this approach is acceptable. If it is, I'll polish it and add tests.

Thank you!